### PR TITLE
fix: improve git file discovery with untracked and removed files #1650

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
     - flake8-docstrings>=1.5.0
     - flake8-pytest-style>=1.2.2
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.902
+  rev: v0.910
   hooks:
   - id: mypy
     # empty args needed in order to match mypy cli behavior

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -206,7 +206,14 @@ class Lintable:
 def discover_lintables(options: Namespace) -> Dict[str, Any]:
     """Find all files that we know how to lint."""
     # git is preferred as it also considers .gitignore
-    git_command_present = ['git', 'ls-files', '--cached', '--others', '--exclude-standard', '-z']
+    git_command_present = [
+        'git',
+        'ls-files',
+        '--cached',
+        '--others',
+        '--exclude-standard',
+        '-z',
+    ]
     git_command_absent = ['git', 'ls-files', '--deleted', '-z']
     out = None
 
@@ -214,7 +221,9 @@ def discover_lintables(options: Namespace) -> Dict[str, Any]:
         out_present = subprocess.check_output(
             git_command_present, stderr=subprocess.STDOUT, universal_newlines=True
         ).split("\x00")[:-1]
-        _logger.info("Discovered files to lint using: %s", ' '.join(git_command_present))
+        _logger.info(
+            "Discovered files to lint using: %s", ' '.join(git_command_present)
+        )
 
         out_absent = subprocess.check_output(
             git_command_absent, stderr=subprocess.STDOUT, universal_newlines=True

--- a/src/ansiblelint/file_utils.py
+++ b/src/ansiblelint/file_utils.py
@@ -206,14 +206,22 @@ class Lintable:
 def discover_lintables(options: Namespace) -> Dict[str, Any]:
     """Find all files that we know how to lint."""
     # git is preferred as it also considers .gitignore
-    git_command = ['git', 'ls-files', '-z']
+    git_command_present = ['git', 'ls-files', '--cached', '--others', '--exclude-standard', '-z']
+    git_command_absent = ['git', 'ls-files', '--deleted', '-z']
     out = None
 
     try:
-        out = subprocess.check_output(
-            git_command, stderr=subprocess.STDOUT, universal_newlines=True
+        out_present = subprocess.check_output(
+            git_command_present, stderr=subprocess.STDOUT, universal_newlines=True
         ).split("\x00")[:-1]
-        _logger.info("Discovered files to lint using: %s", ' '.join(git_command))
+        _logger.info("Discovered files to lint using: %s", ' '.join(git_command_present))
+
+        out_absent = subprocess.check_output(
+            git_command_absent, stderr=subprocess.STDOUT, universal_newlines=True
+        ).split("\x00")[:-1]
+        _logger.info("Excluded removed files using: %s", ' '.join(git_command_absent))
+
+        out = set(out_present) - set(out_absent)
     except subprocess.CalledProcessError as exc:
         if not (exc.returncode == 128 and 'fatal: not a git repository' in exc.output):
             _logger.warning(

--- a/test/TestUtils.py
+++ b/test/TestUtils.py
@@ -354,7 +354,11 @@ def test_cli_auto_detect(capfd: CaptureFixture[str]) -> None:
     out, err = capfd.readouterr()
 
     # Confirmation that it runs in auto-detect mode
-    assert "Discovered files to lint using: git ls-files -z" in err
+    assert (
+        "Discovered files to lint using: git ls-files --cached --others --exclude-standard -z"
+        in err
+    )
+    assert "Excluded removed files using: git ls-files --deleted -z" in err
     # An expected rule match from our examples
     assert (
         "examples/playbooks/empty_playbook.yml:1: "


### PR DESCRIPTION
Closes #1647.

Uses two distinct `git ls-files` commands to obtain a full list of lintable files, including those not yet added to staging area, both new files and removed files.